### PR TITLE
task7-fe completed

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -30,12 +30,16 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
   };
 
   const uploadFile = async (e: any) => {
+       const authorization_token = localStorage.getItem('authorization_token');
       // Get the presigned URL
       const response = await axios({
         method: 'GET',
         url,
         params: {
           name: encodeURIComponent(file.name)
+        },
+        headers: {
+          Authorization: authorization_token ? `Basic ${authorization_token}` : ''
         }
       })
       console.log('File to upload: ', file.name)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,9 @@ axios.interceptors.response.use(
     if (error?.response?.status === 400) {
       alert(error.response.data?.data);
     }
-
+    if (error?.response?.status === 401 || error?.response?.status === 403) {
+			alert(error?.response?.data?.message);
+		}
     return Promise.reject(error?.response ?? error);
   }
 );


### PR DESCRIPTION
### Task#7: https://github.com/EPAM-JS-Competency-center/cloud-development-course-initial/blob/main/7_authorization/task.md

* Backend Repo: https://github.com/caglagezgen/product-api-aws-ts
* Documentation Url: https://r46mv0zp7a.execute-api.us-east-1.amazonaws.com/dev/swagger
* Front End: https://d3v07c3t9s6dd6.cloudfront.net/
* Front End Repo: https://github.com/caglagezgen/shop-react-redux-cloudfront

What is done:

- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser localstorage.

Optional Tasks:

- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.

Self score for TASK-7: 6/6
